### PR TITLE
AWS upload use boto3 managed transfers

### DIFF
--- a/core/data_acquisition/AWS/aws_wrappers.py
+++ b/core/data_acquisition/AWS/aws_wrappers.py
@@ -1,5 +1,6 @@
 from dotenv import load_dotenv
 import boto3
+from botocore.exceptions import ClientError
 import os
 
 """
@@ -19,18 +20,41 @@ class AWSController:
                 aws_secret_access_key=aws_secret_key)
 
     """
-    <summary> Uploads a given file to aws s3 from memory</summary>
-    <param name="file_upload">The file to upload</param>
-    <param name="filename">The name of the uploaded file on aws</param>
+    <summary>Uploads a given file-like object to AWS S3 from memory</summary>
+    <param name="file_obj">The file-like object to upload (must be in binary mode)</param>
     <param name="bucket_name">The name of the bucket to upload the file to</param>
-    <returns></returns>
+    <param name="AWS_key">The name of the key to upload to on AWS</param>
+    <returns>True if file was uploaded, else False</returns>
     """
-    def upload_csv(self, file_upload, filename, bucket_name):
-        self.s3_client.put_object(
-                Bucket = bucket_name,
-                Key = filename,
-                Body = file_upload
+    def upload_file_from_memory(self, file_obj, bucket_name, AWS_key):
+        try:
+            self.s3_client.upload_fileobj(
+                file_obj,
+                bucket_name,
+                AWS_key
             )
+        except ClientError:
+            return False
+        return True
+
+
+    """
+    <summary>Uploads a given file to AWS S3 from the disk</summary>
+    <param name="filepath">The path of the file to upload</param>
+    <param name="bucket_name">The name of the bucket to upload the file to</param>
+    <param name="AWS_key">The name of the key to upload to on AWS</param>
+    <returns>True if file was uploaded, else False</returns>
+    """
+    def upload_file_from_disk(self, filepath, bucket_name, AWS_key):
+        try:
+            self.s3_client.upload_file(
+                filepath,
+                bucket_name,
+                AWS_key
+            )
+        except ClientError:
+            return False
+        return True
 
     """
     <summary> Deletes a given file in AWS S3 </summary>


### PR DESCRIPTION
Changed file uploading methods to be multipart transfers, allowing file sizes > 5GB. Also added method to upload file from disk.